### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -15552,7 +15552,7 @@ var tabs = $.widget( "ui.tabs", {
 	},
 
 	_sanitizeSelector: function( hash ) {
-		return hash ? hash.replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
+		return hash ? hash.replace( /[\\!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
 	},
 
 	refresh: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/PKgwediaphuku/NasArts/security/code-scanning/4](https://github.com/PKgwediaphuku/NasArts/security/code-scanning/4)

To fix this problem, we need to ensure that the backslash character is also escaped when sanitizing the selector string. This requires updating the regular expression in `_sanitizeSelector` to include `\\` among the characters to be replaced. Specifically, change the regex from `/[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g` to `/[\\!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g`. This change should be made on line 15555 within the `_sanitizeSelector` method in the file `js/tabs.js`. No additional imports or helper functions are required, as this is a simple update to a regular expression within an internal utility function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
