### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -3399,7 +3399,7 @@ var lastActive,
 			form = radio.form,
 			radios = $( [] );
 		if ( name ) {
-			name = name.replace( /'/g, "\\'" );
+			name = name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 			if ( form ) {
 				radios = $( form ).find( "[name='" + name + "'][type=radio]" );
 			} else {


### PR DESCRIPTION
Potential fix for [https://github.com/PKgwediaphuku/NasArts/security/code-scanning/3](https://github.com/PKgwediaphuku/NasArts/security/code-scanning/3)

To fully and correctly escape the input, we need to escape both backslashes and apostrophes in the radio button name before embedding it in the selector string. The best method is to use two `.replace()` calls with global flags:

1. First, escape each backslash (`\`) by replacing it with double backslashes (`\\`).  
2. Next, escape each apostrophe (`'`) by replacing it with backslash-apostrophe (`\'`).  

Order matters: We first escape backslashes so that any new backslashes introduced for apostrophe escaping don't themselves get escaped twice.  
Therefore, line 3402 should be changed from:
```js
name = name.replace(/'/g, "\\'");
```
to:
```js
name = name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
```
No additional imports are needed, as this only uses native String methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
