### PR TITLE
Potential fix for code scanning alert no. 36: Unsafe HTML constructed from library input

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -7110,7 +7110,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 				handle = $.trim(n[i]);
 				hname = "ui-resizable-" + handle;
-				axis = $("<div class='ui-resizable-handle " + hname + "'></div>");
+				axis = $("<div>").addClass("ui-resizable-handle").addClass(hname);
 
 				axis.css({ zIndex: o.zIndex });
 


### PR DESCRIPTION
Potential fix for [https://github.com/PKgwediaphuku/NasArts/security/code-scanning/36](https://github.com/PKgwediaphuku/NasArts/security/code-scanning/36)

The best way to fix this problem is to ensure that the dynamically constructed HTML does not allow injection via the `handle` variable. Creating DOM nodes with classes should be done through methods that do not use HTML strings interpolated with untrusted data. Specifically, rather than assembling a string that might include malicious content (`$("<div class='ui-resizable-handle " + hname + "'></div>")`), we should use the DOM/jQuery API to assign classes safely using the `.addClass()` method, which does not interpret its input as HTML.

Edit only the relevant block (lines 7111–7114).  
- Replace the code to create the `<div>` with a plain `"<div>"`, then assign classes using `.addClass()`.  
- No new imports are needed because jQuery is already present and being used.
- This ensures that even if `handle` contains malicious characters, it will not break out of the class attribute or introduce XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
