### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/vendor/jquery/jquery.js
+++ b/vendor/jquery/jquery.js
@@ -5793,7 +5793,7 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {


### PR DESCRIPTION
Potential fix for [https://github.com/PKgwediaphuku/NasArts/security/code-scanning/1](https://github.com/PKgwediaphuku/NasArts/security/code-scanning/1)

**General Strategy:**  
Replace the unsafe expansion logic with a safe alternative. Do not attempt to parse HTML with regular expressions. Instead, if an application must handle self-closing tags, it should use a proper HTML parser (e.g., DOMParser in the browser, or a well-tested library) or otherwise leave self-closing tags as is. For legacy reasons, jQuery's `htmlPrefilter` is sometimes used to ensure consistent tag closure, but this presents security risks.

**Best Fix:**  
- Remove or rewrite the regular expression-based expansion in the `htmlPrefilter` function.
- Ideally, make `htmlPrefilter` a NO-OP (returns input as-is), or use a library call to robustly perform any necessary tag normalization.
- **In `vendor/jquery/jquery.js`:**  
  - On line 5796, replace `return html.replace( rxhtmlTag, "<$1></$2>" );` with `return html;`
- Leave the definition of `rxhtmlTag` in place (for backwards compatibility unless it's unused), but render the function itself safe.
- No additional imports needed, as the safest action is to perform no transformation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
